### PR TITLE
chore: dotenv 제거 / firebase 에러 관련 기록

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "dotenv": "^10.0.0",
     "firebase": "^9.4.1",
     "next": "12.0.1",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,11 +1372,6 @@ domain-browser@4.19.0:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-4.19.0.tgz#1093e17c0a17dbd521182fe90d49ac1370054af1"
   integrity sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ==
 
-dotenv@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
-  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
-
 electron-to-chromium@^1.3.723:
   version "1.3.802"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.802.tgz#0afa989321de3e904ac653ee79e0d642883731a1"


### PR DESCRIPTION
**[문제]**
강의에 나온 코드를 그대로 사용하였음에도 불구하고 아래 에러를 비롯하여 firebase 모듈 관련 에러들이 발생함.
```
ERROR Error: Uncaught (in promise):
[DEFAULT]: Firebase: No Firebase App ‘[DEFAULT]’ has been created
– call Firebase App.initializeApp() (app/no-app).
```

**[원인]**
- 근본적인 원인은 강의가 촬영된 당시와 현재의 firebase 버전이 달라서였음. (강의에선 v7 현재는 v9)
  - 기존에 작성된 코드는 이 [firebase 문서](https://firebase.google.com/docs/auth/web/start?hl=ko#web-version-9)에서와 같이 웹 버전 8 방식으로 작성되어있어 v9에서 제대로 동작하지 않아 웹 버전 9 방식에 따라 수정하니 잘 작동함.

**[기타]**
- Next.js 환경변수
  - [참고 포스팅](https://tigger.dev/entry/Nextjs-%EC%97%90%EC%84%9C-%ED%99%98%EA%B2%BD%EB%B3%80%EC%88%98-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EA%B8%B0-feat-Vercel)
  - Next.js에선 자체적으로 환경변수 접근이 가능하므로 dotenv 설치할 필요 없음. 그런데 firebase 에러를 수정한 이후 잘 동작하던 앱이 배포가 완료되자 아예 동작하지를 않음. 유효하지 않은 api key라는 메시지가 뜨길래 환경변수를 못읽는 것 같아 서치를 해보니, 위 포스트 내용과 같이 Vercel에 배포를 할 때는 해당 프로젝트에서 직접 env 설정을 해줘야 한다고 함. 참고해서 수정하여 해결함.
- `Firebase: Error (auth/unauthorized-domain).`
  - [참고 stackoverflow](https://stackoverflow.com/questions/48076968/firebase-auth-unauthorized-domain-domain-is-not-authorized)
  - 도메인 등록해주니 화면이 제대로 나왔지만, Sign in 버튼을 클릭하자 `FirebaseError: Firebase: Error (auth/unauthorized-domain).` 에러가 발생함. firebase 콘솔 → '빌드' 하위메뉴 중 Authentication → 승인된 도메인 → 도메인 추가 버튼 클릭하여 애플리케이션 도메인 등록하여 해결함.